### PR TITLE
Add Codex limit display

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ This tool helps detect if ChatGPT has limited access to certain features on your
 
    _(Note: PoW levels can vary even for the same IP. For example, after completing a higher difficulty PoW, the next one may be slightly easier, although it typically won’t drop to “simple.”)_
 
+### Codex Usage Tracking
+When visiting `https://chatgpt.com/codex`, the PoW endpoint is unavailable. The userscript now reads the Wham rate-limit API and displays a progress bar showing how many Codex tasks you have used and how long until the quota resets.
+
 ## What Is a Service Downgrade?
 When certain IPs are flagged as high-risk, ChatGPT may silently downgrade access by switching to a lower-tier model, such as the 4o-mini variant or a simpler model, without notifying the user.
 
@@ -39,6 +42,9 @@ For users experiencing sudden changes in ChatGPT functionality—like missing im
 作为参考，这个值在超过 5 位时，一般代表你的ip较为优质，可以正常使用所有服务，如果小于等于 000032，说明你的 ip 被认为有很高的风险。
 
 （更详细的区分尚不清晰，我简单测试了几个 ip，发现即便对同一个 ip，其要求的 PoW 也很容易变动，例如，如果已经完成了一个较困难的 PoW，下一次的 PoW 难度就会稍稍降低，但不会降低到“简单”级别。）
+
+### Codex 使用量
+访问 `https://chatgpt.com/codex` 时无法获取 PoW 信息，脚本会调用 Wham 接口显示 Codex 当前额度，并以进度条展示剩余次数和重置倒计时。
 
 ## 什么是服务降级？
 ChatGPT 会对一些被判断为高风险的 ip 降级服务，偷偷将模型切换为 4o-mini 或者更差，并且**没有任何提示**。

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This tool helps detect if ChatGPT has limited access to certain features on your
    _(Note: PoW levels can vary even for the same IP. For example, after completing a higher difficulty PoW, the next one may be slightly easier, although it typically won’t drop to “simple.”)_
 
 ### Codex Usage Tracking
-When visiting `https://chatgpt.com/codex`, the PoW endpoint is unavailable. The userscript now intercepts the Wham rate-limit API response and displays a purple progress bar showing how many Codex tasks you have used and how long until the quota resets.
+When visiting `https://chatgpt.com/codex`, the PoW endpoint is unavailable. The userscript intercepts the Wham rate-limit API response and displays a purple progress bar showing how many Codex tasks you have used and how long until the quota resets. If PoW data cannot be retrieved, the PoW section is hidden and the circular icon turns purple to indicate Codex status.
 
 ## What Is a Service Downgrade?
 When certain IPs are flagged as high-risk, ChatGPT may silently downgrade access by switching to a lower-tier model, such as the 4o-mini variant or a simpler model, without notifying the user.
@@ -44,7 +44,7 @@ For users experiencing sudden changes in ChatGPT functionality—like missing im
 （更详细的区分尚不清晰，我简单测试了几个 ip，发现即便对同一个 ip，其要求的 PoW 也很容易变动，例如，如果已经完成了一个较困难的 PoW，下一次的 PoW 难度就会稍稍降低，但不会降低到“简单”级别。）
 
 ### Codex 使用量
-访问 `https://chatgpt.com/codex` 时无法获取 PoW 信息，脚本会拦截 Wham 接口的返回数据显示 Codex 当前额度，并以紫色进度条展示剩余次数和重置倒计时。
+访问 `https://chatgpt.com/codex` 时无法获取 PoW 信息，脚本会拦截 Wham 接口的返回数据显示 Codex 当前额度，并以紫色进度条展示剩余次数和重置倒计时。如果无法获取 PoW 数据，会隐藏 PoW 信息，并把圆形图标变成紫色表示 Codex 状态。
 
 ## 什么是服务降级？
 ChatGPT 会对一些被判断为高风险的 ip 降级服务，偷偷将模型切换为 4o-mini 或者更差，并且**没有任何提示**。

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This tool helps detect if ChatGPT has limited access to certain features on your
    _(Note: PoW levels can vary even for the same IP. For example, after completing a higher difficulty PoW, the next one may be slightly easier, although it typically won’t drop to “simple.”)_
 
 ### Codex Usage Tracking
-When visiting `https://chatgpt.com/codex`, the PoW endpoint is unavailable. The userscript now reads the Wham rate-limit API and displays a progress bar showing how many Codex tasks you have used and how long until the quota resets.
+When visiting `https://chatgpt.com/codex`, the PoW endpoint is unavailable. The userscript now intercepts the Wham rate-limit API response and displays a progress bar showing how many Codex tasks you have used and how long until the quota resets.
 
 ## What Is a Service Downgrade?
 When certain IPs are flagged as high-risk, ChatGPT may silently downgrade access by switching to a lower-tier model, such as the 4o-mini variant or a simpler model, without notifying the user.
@@ -44,7 +44,7 @@ For users experiencing sudden changes in ChatGPT functionality—like missing im
 （更详细的区分尚不清晰，我简单测试了几个 ip，发现即便对同一个 ip，其要求的 PoW 也很容易变动，例如，如果已经完成了一个较困难的 PoW，下一次的 PoW 难度就会稍稍降低，但不会降低到“简单”级别。）
 
 ### Codex 使用量
-访问 `https://chatgpt.com/codex` 时无法获取 PoW 信息，脚本会调用 Wham 接口显示 Codex 当前额度，并以进度条展示剩余次数和重置倒计时。
+访问 `https://chatgpt.com/codex` 时无法获取 PoW 信息，脚本会拦截 Wham 接口的返回数据显示 Codex 当前额度，并以进度条展示剩余次数和重置倒计时。
 
 ## 什么是服务降级？
 ChatGPT 会对一些被判断为高风险的 ip 降级服务，偷偷将模型切换为 4o-mini 或者更差，并且**没有任何提示**。

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This tool helps detect if ChatGPT has limited access to certain features on your
    _(Note: PoW levels can vary even for the same IP. For example, after completing a higher difficulty PoW, the next one may be slightly easier, although it typically won’t drop to “simple.”)_
 
 ### Codex Usage Tracking
-When visiting `https://chatgpt.com/codex`, the PoW endpoint is unavailable. The userscript now intercepts the Wham rate-limit API response and displays a progress bar showing how many Codex tasks you have used and how long until the quota resets.
+When visiting `https://chatgpt.com/codex`, the PoW endpoint is unavailable. The userscript now intercepts the Wham rate-limit API response and displays a purple progress bar showing how many Codex tasks you have used and how long until the quota resets.
 
 ## What Is a Service Downgrade?
 When certain IPs are flagged as high-risk, ChatGPT may silently downgrade access by switching to a lower-tier model, such as the 4o-mini variant or a simpler model, without notifying the user.
@@ -44,7 +44,7 @@ For users experiencing sudden changes in ChatGPT functionality—like missing im
 （更详细的区分尚不清晰，我简单测试了几个 ip，发现即便对同一个 ip，其要求的 PoW 也很容易变动，例如，如果已经完成了一个较困难的 PoW，下一次的 PoW 难度就会稍稍降低，但不会降低到“简单”级别。）
 
 ### Codex 使用量
-访问 `https://chatgpt.com/codex` 时无法获取 PoW 信息，脚本会拦截 Wham 接口的返回数据显示 Codex 当前额度，并以进度条展示剩余次数和重置倒计时。
+访问 `https://chatgpt.com/codex` 时无法获取 PoW 信息，脚本会拦截 Wham 接口的返回数据显示 Codex 当前额度，并以紫色进度条展示剩余次数和重置倒计时。
 
 ## 什么是服务降级？
 ChatGPT 会对一些被判断为高风险的 ip 降级服务，偷偷将模型切换为 4o-mini 或者更差，并且**没有任何提示**。

--- a/chatgpt-degrade-checker.user.js
+++ b/chatgpt-degrade-checker.user.js
@@ -44,10 +44,10 @@
         displayBox.style.display = "none";
 
         displayBox.innerHTML = `
-        <div style="margin-bottom: 10px;">
-            <strong>PoW 信息</strong>
-        </div>
-        <div id="content">
+        <div id="pow-section">
+            <div style="margin-bottom: 10px;">
+                <strong>PoW 信息</strong>
+            </div>
             PoW难度: <span id="difficulty">N/A</span><span id="difficulty-level" style="margin-left: 3px"></span>
             <span id="difficulty-tooltip" style="
                 cursor: pointer;
@@ -64,13 +64,13 @@
             ">?</span><br>
             IP质量: <span id="ip-quality">N/A</span><br>
             <span id="persona-container" style="display: none">用户类型: <span id="persona">N/A</span></span>
-            <div id="codex-section" style="margin-top: 10px; display: none">
-                <div style="margin-bottom: 6px;"><strong>Codex 额度</strong></div>
-                <div id="codex-progress-bg" style="width: 100%; height: 8px; background: #555; border-radius: 4px;">
-                    <div id="codex-progress-bar" style="height: 100%; width: 0%; background: #9c27b0; border-radius: 4px;"></div>
-                </div>
-                <div id="codex-info" style="margin-top: 4px; font-size: 12px;">N/A</div>
+        </div>
+        <div id="codex-section" style="margin-top: 10px; display: none">
+            <div style="margin-bottom: 6px;"><strong>Codex 额度</strong></div>
+            <div id="codex-progress-bg" style="width: 100%; height: 8px; background: #555; border-radius: 4px;">
+                <div id="codex-progress-bar" style="height: 100%; width: 0%; background: #9c27b0; border-radius: 4px;"></div>
             </div>
+            <div id="codex-info" style="margin-top: 4px; font-size: 12px;">N/A</div>
         </div>
         <div style="
             margin-top: 12px;
@@ -229,6 +229,9 @@
     }
     startObserverWhenReady();
 
+    let powFetched = false;
+    let codexFetched = false;
+
     // 更新difficulty指示器
     function updateDifficultyIndicator(difficulty) {
         const difficultyLevel = document.getElementById("difficulty-level");
@@ -238,6 +241,9 @@
             setIconColors("#888", "#666");
             difficultyLevel.innerText = "";
             ipQuality.innerHTML = "N/A";
+            powFetched = false;
+            const powSection = document.getElementById("pow-section");
+            if (powSection && codexFetched) powSection.style.display = "none";
             return;
         }
 
@@ -275,6 +281,9 @@
         setIconColors(color, secondaryColor);
         difficultyLevel.innerHTML = `<span style="color: ${textColor}">${level}</span>`;
         ipQuality.innerHTML = `<span style="color: ${textColor}">${qualityText}</span>`;
+        powFetched = true;
+        const powSection = document.getElementById("pow-section");
+        if (powSection) powSection.style.display = "block";
     }
 
     function setIconColors(primaryColor, secondaryColor) {
@@ -307,6 +316,12 @@
         bar.style.background = "#9c27b0";
         section.style.display = "block";
         codexResetTime = Date.now() + resetsAfter * 1000;
+        codexFetched = true;
+        if (!powFetched) {
+            setIconColors("#9c27b0", "#7b1fa2");
+            const powSection = document.getElementById("pow-section");
+            if (powSection) powSection.style.display = "none";
+        }
         updateCodexCountdown();
     }
 

--- a/chatgpt-degrade-checker.user.js
+++ b/chatgpt-degrade-checker.user.js
@@ -4,7 +4,7 @@
 // @homepage     https://github.com/zetaloop/chatgpt-degrade-checker-next
 // @author       zetaloop
 // @icon         data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA2NCA2NCI+PHBhdGggZmlsbD0iIzJjM2U1MCIgZD0iTTMyIDJDMTUuNDMyIDIgMiAxNS40MzIgMiAzMnMxMy40MzIgMzAgMzAgMzAgMzAtMTMuNDMyIDMwLTMwUzQ4LjU2OCAyIDMyIDJ6bTAgNTRjLTEzLjIzMyAwLTI0LTEwLjc2Ny0yNC0yNFMxOC43NjcgOCAzMiA4czI0IDEwLjc2NyAyNCAyNFM0NS4yMzMgNTYgMzIgNTZ6Ii8+PHBhdGggZmlsbD0iIzNkYzJmZiIgZD0iTTMyIDEyYy0xMS4wNDYgMC0yMCA4Ljk1NC0yMCAyMHM4Ljk1NCAyMCAyMCAyMCAyMC04Ljk1NCAyMC0yMFM0My4wNDYgMTIgMzIgMTJ6bTAgMzZjLTguODM3IDAtMTYtNy4xNjMtMTYtMTZzNy4xNjMtMTYgMTYtMTYgMTYgNy4xNjMgMTYgMTZTNDAuODM3IDQ4IDMyIDQ4eiIvPjxwYXRoIGZpbGw9IiMwMGZmN2YiIGQ9Ik0zMiAyMGMtNi42MjcgMC0xMiA1LjM3My0xMiAxMnM1LjM3MyAxMiAxMiAxMiAxMi01LjM3MyAxMi0xMlMzOC42MjcgMjAgMzIgMjB6bTAgMjBjLTQuNDE4IDAtOC0zLjU4Mi04LThzMy41ODItOCA4LTggOCAzLjU4MiA4IDgtMy41ODIgOC04IDh6Ii8+PGNpcmNsZSBmaWxsPSIjZmZmIiBjeD0iMzIiIGN5PSIzMiIgcj0iNCIvPjwvc3ZnPg==
-// @version      2.1.0
+// @version      2.2.0
 // @description  由于 ChatGPT 会对某些 ip 进行无提示的服务降级，此脚本用于检测你的 ip 在 ChatGPT 数据库中的风险等级。
 // @match        *://chatgpt.com/*
 // @grant        none
@@ -67,7 +67,7 @@
             <div id="codex-section" style="margin-top: 10px; display: none">
                 <div style="margin-bottom: 6px;"><strong>Codex 额度</strong></div>
                 <div id="codex-progress-bg" style="width: 100%; height: 8px; background: #555; border-radius: 4px;">
-                    <div id="codex-progress-bar" style="height: 100%; width: 0%; background: #4caf50; border-radius: 4px;"></div>
+                    <div id="codex-progress-bar" style="height: 100%; width: 0%; background: #9c27b0; border-radius: 4px;"></div>
                 </div>
                 <div id="codex-info" style="margin-top: 4px; font-size: 12px;">N/A</div>
             </div>
@@ -287,6 +287,8 @@
 
     // 更新 Codex 额度进度条
     let codexResetTime = null;
+    let codexLimit = null;
+    let codexUsed = null;
     function updateCodexInfo(limit, remaining, resetsAfter) {
         const section = document.getElementById("codex-section");
         const bar = document.getElementById("codex-progress-bar");
@@ -298,22 +300,26 @@
             return;
         }
 
-        const used = limit - remaining;
-        const percent = Math.max(0, Math.min(100, (used / limit) * 100));
+        codexLimit = limit;
+        codexUsed = limit - remaining;
+        const percent = Math.max(0, Math.min(100, (codexUsed / limit) * 100));
         bar.style.width = `${percent}%`;
+        bar.style.background = "#9c27b0";
         section.style.display = "block";
         codexResetTime = Date.now() + resetsAfter * 1000;
-        info.innerText = `已用 ${used}/${limit}`;
+        updateCodexCountdown();
     }
 
     function updateCodexCountdown() {
         const info = document.getElementById("codex-info");
         if (!info || !codexResetTime) return;
-        const remaining = Math.max(0, Math.floor((codexResetTime - Date.now()) / 1000));
-        const minutes = Math.floor(remaining / 60);
-        const seconds = remaining % 60;
-        info.innerText = info.innerText.replace(/重置.*$/, "") +
-            `，重置倒计时 ${minutes}:${seconds.toString().padStart(2, "0")}`;
+        if (codexLimit === null || codexUsed === null) return;
+        const remainingSecs = Math.max(0, Math.floor((codexResetTime - Date.now()) / 1000));
+        const minutes = Math.floor(remainingSecs / 60);
+        const seconds = remainingSecs % 60;
+        info.innerText = `已用 ${codexUsed}/${codexLimit}，重置倒计时 ${minutes}:${seconds
+            .toString()
+            .padStart(2, "0")}`;
     }
     setInterval(updateCodexCountdown, 1000);
 


### PR DESCRIPTION
## Summary
- display Codex task quota when browsing `/codex`
- poll wham API and show a progress bar with reset countdown
- document Codex quota feature in README

## Testing
- `node -c chatgpt-degrade-checker.user.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6846c2afc8dc83208bc7c4905832a91e